### PR TITLE
feat: add --log-level flag to control logging verbosity

### DIFF
--- a/src/bitcoin_mcp/server.py
+++ b/src/bitcoin_mcp/server.py
@@ -20,7 +20,6 @@ from bitcoinlib_rpc.status import get_status as _get_status
 from bitcoinlib_rpc.transactions import analyze_transaction as _analyze_transaction
 from bitcoinlib_rpc.utils import fee_recommendation
 
-logging.basicConfig(level=logging.INFO, stream=sys.stderr)
 logger = logging.getLogger("bitcoin-mcp")
 
 mcp = FastMCP(
@@ -1875,7 +1874,14 @@ def main():
     )
     parser.add_argument("--host", default=None, help="Host for HTTP transports (default: 127.0.0.1)")
     parser.add_argument("--port", type=int, default=None, help="Port for HTTP transports (default: 8000)")
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Logging verbosity (default: INFO)",
+    )
     args = parser.parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level), stream=sys.stderr, force=True)
 
     if args.check:
         try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -440,6 +440,37 @@ class TestCLIFlags:
         )
         assert __version__ in result.stdout or __version__ in result.stderr
         assert result.returncode == 0
+    
+    @pytest.mark.parametrize(
+        "level",
+        ["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    def test_log_level_flag_accepts_values(self, level):
+        """
+        Verify the --log-level flag is accepted by argparse for all valid values.
+        """
+        result = subprocess.run(
+            [sys.executable, "-m", "bitcoin_mcp.server", "--log-level", level, "--check"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode in (0, 1)
+
+    @pytest.mark.parametrize(
+        "level",
+        ["HELLO", "SORRY", "ERR", "WARN"],
+    )
+    def test_log_level_flag_rejects_invalid(self, level):
+        """
+        Verify argparse rejects invalid --log-level values with returncode 2.
+        """
+        result = subprocess.run(
+            [sys.executable, "-m", "bitcoin_mcp.server", "--log-level", level, "--check"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+        assert f"invalid choice: '{level}'" in result.stderr
 
 
 class TestMultiNetworkPort:


### PR DESCRIPTION
Add a --log-level CLI flag to allow configuring the logging verbosity
of the bitcoin-mcp.

The change ensures the selected log level properly controls log output.

Issue: #12