### PR TITLE
Add py.typed marker and return type annotations to l402_client.py

### DIFF
--- a/src/bitcoin_mcp/l402_client.py
+++ b/src/bitcoin_mcp/l402_client.py
@@ -7,12 +7,15 @@ Handles the full L402 flow:
 4. Cache valid tokens for reuse
 """
 
+from __future__ import annotations
+
 import base64
 import hashlib
 import json
 import logging
 import os
 import time
+from typing import Self
 
 log = logging.getLogger(__name__)
 
@@ -102,24 +105,24 @@ class L402Client:
         except Exception as e:
             raise L402ProtocolError(f"Failed to extract payment hash: {e}")
 
-    def close(self):
+    def close(self) -> None:
         self.client.close()
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: object) -> None:
         self.close()
 
 
 class L402PaymentRequired(Exception):
-    def __init__(self, response):
+    def __init__(self, response: httpx.Response) -> None:
         self.response = response
         super().__init__(f"Payment required: {response.status_code}")
 
 
 class L402PriceTooHigh(Exception):
-    def __init__(self, price: int, max_price: int):
+    def __init__(self, price: int, max_price: int) -> None:
         self.price = price
         self.max_price = max_price
         super().__init__(f"Price {price} sats exceeds max {max_price} sats")


### PR DESCRIPTION
## Summary

Fixes #11

This PR adds the PEP 561 `py.typed` marker and completes return type annotations in `l402_client.py`.

## Changes

1. **Created `src/bitcoin_mcp/py.typed`** — empty PEP 561 marker file so type checkers (mypy, pyright) recognize the package as typed.

2. **Added return type annotations to `l402_client.py`:**
   - `L402Client.close()` → `None`
   - `L402Client.__enter__()` → `Self`
   - `L402Client.__exit__()` → `None` (also added proper parameter types)
   - `L402PaymentRequired.__init__()` → `None`
   - `L402PriceTooHigh.__init__()` → `None`

3. **Added `from __future__ import annotations`** and `Self` import from `typing`.

## Testing

- Type annotation changes only, no behavioral changes
- `py.typed` file is included in the package via hatchling's default behavior (packages under `src/bitcoin_mcp/`)

## Acceptance Criteria

- [x] `src/bitcoin_mcp/py.typed` exists (empty file)
- [x] All functions in `l402_client.py` have complete type annotations
- [x] Package still installs correctly with `pip install -e .`