### PR TITLE
Add --log-level CLI flag for debug logging

### DIFF
--- a/src/bitcoin_mcp/server.py
+++ b/src/bitcoin_mcp/server.py
@@ -20,7 +20,6 @@ from bitcoinlib_rpc.status import get_status as _get_status
 from bitcoinlib_rpc.transactions import analyze_transaction as _analyze_transaction
 from bitcoinlib_rpc.utils import fee_recommendation
 
-logging.basicConfig(level=logging.INFO, stream=sys.stderr)
 logger = logging.getLogger("bitcoin-mcp")
 
 mcp = FastMCP(
@@ -1875,7 +1874,15 @@ def main():
     )
     parser.add_argument("--host", default=None, help="Host for HTTP transports (default: 127.0.0.1)")
     parser.add_argument("--port", type=int, default=None, help="Port for HTTP transports (default: 8000)")
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Logging verbosity (default: INFO)",
+    )
     args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level), stream=sys.stderr)
 
     if args.check:
         try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -441,6 +441,29 @@ class TestCLIFlags:
         assert __version__ in result.stdout or __version__ in result.stderr
         assert result.returncode == 0
 
+    def test_log_level_accepted(self):
+        """--log-level flag is accepted by argparse without error."""
+        for level in ["DEBUG", "INFO", "WARNING", "ERROR"]:
+            result = subprocess.run(
+                [sys.executable, "-m", "bitcoin_mcp.server", "--log-level", level, "--check"],
+                capture_output=True, text=True,
+                env={**os.environ, "SATOSHI_API_URL": "https://bitcoinsapi.com"},
+                cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                timeout=15,
+            )
+            # Should not fail with argparse error; may fail on connection but that's OK
+            assert "unrecognized arguments" not in result.stderr, f"Rejected --log-level {level}"
+
+    def test_invalid_log_level_rejected(self):
+        """--log-level with invalid value is rejected."""
+        result = subprocess.run(
+            [sys.executable, "-m", "bitcoin_mcp.server", "--log-level", "INVALID"],
+            capture_output=True, text=True,
+            cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        )
+        assert result.returncode != 0
+        assert "invalid choice" in result.stderr.lower() or "INVALID" in result.stderr
+
 
 class TestMultiNetworkPort:
     """Tests for multi-network port selection."""


### PR DESCRIPTION
## Summary

Fixes #12

This PR adds a `--log-level` CLI flag to control logging verbosity, and moves the module-level `logging.basicConfig` call into `main()` so it respects the flag.

## Changes

1. **Removed module-level `logging.basicConfig`** from line 23 — logging is now configured in `main()` after argument parsing.

2. **Added `--log-level` argument** to argparse with choices: DEBUG, INFO, WARNING, ERROR (default: INFO).

3. **Added tests:**
   - `test_log_level_accepted` — verifies all valid levels are accepted
   - `test_invalid_log_level_rejected` — verifies invalid values are rejected

## Usage

```bash
# Default (INFO)
bitcoin-mcp

# Debug mode for troubleshooting
bitcoin-mcp --log-level DEBUG

# Quiet mode
bitcoin-mcp --log-level WARNING
```

## Acceptance Criteria

- [x] `bitcoin-mcp --log-level DEBUG` produces debug output on stderr
- [x] `bitcoin-mcp` with no flag defaults to INFO (no breaking change)
- [x] `bitcoin-mcp --log-level WARNING` suppresses info messages
- [x] Added tests verifying the flag is accepted by argparse
- [x] Module-level `logging.basicConfig` removed