### PR TITLE
Add input validation for address parameters (#10)

### DIFF
--- a/src/bitcoin_mcp/address_validation.py
+++ b/src/bitcoin_mcp/address_validation.py
@@ -1,0 +1,66 @@
+"""Bitcoin address format validation helpers."""
+
+
+# Known valid prefixes for Bitcoin addresses
+# Mainnet: 1 (P2PKH), 3 (P2SH), bc1 (Bech32/Bech32m)
+# Testnet: m/n (P2PKH), 2 (P2SH), tb1 (Bech32/Bech32m)
+# Regtest: bcrt1 (Bech32/Bech32m)
+VALID_ADDRESS_PREFIXES = (
+    "1", "3", "bc1q", "bc1p",  # mainnet
+    "tb1q", "tb1p", "m", "n", "2",  # testnet
+    "bcrt1q", "bcrt1p",  # regtest
+)
+
+VALID_PREFIXES_LIST = ", ".join(f"`{p}`" for p in VALID_ADDRESS_PREFIXES)
+
+MIN_ADDRESS_LENGTH = 25
+MAX_ADDRESS_LENGTH = 90
+
+
+def _validate_address_format(address: str) -> str | None:
+    """Validate that a Bitcoin address format is at least plausible.
+
+    This is a fast sanity check, not full cryptographic validation.
+    It catches empty strings, obviously wrong lengths, and unknown prefixes.
+
+    Args:
+        address: The Bitcoin address string to validate.
+
+    Returns:
+        An error message string if the address is obviously invalid, or
+        ``None`` if the address passes the basic format checks.
+
+    Examples:
+        >>> _validate_address_format("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")
+        None
+        >>> _validate_address_format("")
+        'Address cannot be empty.'
+        >>> _validate_address_format("too short")
+        'Invalid address length (9). Bitcoin addresses are 25-90 characters.'
+        >>> _validate_address_format("https://example.com")
+        'Unrecognized address format. Valid prefixes are: ...'
+    """
+    if not address or not address.strip():
+        return "Address cannot be empty."
+
+    stripped = address.strip()
+
+    if len(stripped) < MIN_ADDRESS_LENGTH:
+        return (
+            f"Invalid address length ({len(stripped)}). "
+            f"Bitcoin addresses are {MIN_ADDRESS_LENGTH}-{MAX_ADDRESS_LENGTH} characters."
+        )
+
+    if len(stripped) > MAX_ADDRESS_LENGTH:
+        return (
+            f"Invalid address length ({len(stripped)}). "
+            f"Bitcoin addresses are {MIN_ADDRESS_LENGTH}-{MAX_ADDRESS_LENGTH} characters."
+        )
+
+    if not any(stripped.startswith(prefix) for prefix in VALID_ADDRESS_PREFIXES):
+        return (
+            f"Unrecognized address format `{stripped[:20]}...`. "
+            f"Valid prefixes are: {VALID_PREFIXES_LIST}."
+        )
+
+    return None

--- a/src/bitcoin_mcp/server.py
+++ b/src/bitcoin_mcp/server.py
@@ -11,6 +11,7 @@ import urllib.error
 
 from mcp.server.fastmcp import FastMCP
 
+from .address_validation import _validate_address_format
 from bitcoinlib_rpc import BitcoinRPC
 from bitcoinlib_rpc.blocks import analyze_block as _analyze_block
 from bitcoinlib_rpc.fees import get_fee_estimates as _get_fee_estimates
@@ -821,6 +822,9 @@ def get_address_utxos(address: str) -> str:
     Args:
         address: Bitcoin address to scan
     """
+    error = _validate_address_format(address)
+    if error:
+        return json.dumps({"error": f"Invalid address: {error}"})
     try:
         result = get_rpc().scantxoutset("start", [f"addr({address})"])
     except Exception as e:
@@ -835,6 +839,9 @@ def validate_address(address: str) -> str:
     Args:
         address: Bitcoin address to validate (any format: P2PKH, P2SH, P2WPKH, P2WSH, P2TR)
     """
+    error = _validate_address_format(address)
+    if error:
+        return json.dumps({"error": f"Invalid address: {error}"})
     try:
         result = get_rpc().validateaddress(address)
     except Exception as e:
@@ -1510,6 +1517,9 @@ def get_address_balance(address: str) -> str:
     Args:
         address: Bitcoin address (any format: legacy, P2SH, bech32, bech32m)
     """
+    error = _validate_address_format(address)
+    if error:
+        return json.dumps({"error": f"Invalid address: {error}"})
     result = _query_indexed_api(f"address/{address}/balance")
     if "error" not in result:
         return json.dumps(result)
@@ -1545,6 +1555,9 @@ def get_address_history(address: str, offset: int = 0, limit: int = 25) -> str:
         offset: Skip this many transactions (for pagination, default 0)
         limit: Max transactions to return (default 25, max 100)
     """
+    error = _validate_address_format(address)
+    if error:
+        return json.dumps({"error": f"Invalid address: {error}"})
     limit = min(limit, 100)
     result = _query_indexed_api(f"address/{address}/txs?offset={offset}&limit={limit}")
     if "error" not in result:

--- a/tests/test_address_validation.py
+++ b/tests/test_address_validation.py
@@ -1,0 +1,102 @@
+"""Tests for Bitcoin address validation."""
+
+import pytest
+
+
+class TestValidateAddressFormat:
+    """Tests for the _validate_address_format helper."""
+
+    def test_empty_string_returns_error(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("")
+        assert result is not None
+        assert "cannot be empty" in result
+
+    def test_whitespace_only_returns_error(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("   ")
+        assert result is not None
+        assert "cannot be empty" in result
+
+    def test_none_returns_error(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format(None)
+        assert result is not None
+        assert "cannot be empty" in result
+
+    def test_too_short_address_returns_error(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("1A1zP1eP5")
+        assert result is not None
+        assert "Invalid address length" in result
+        assert "9" in result  # the length should be mentioned
+
+    def test_too_long_address_returns_error(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        long_addr = "1" * 100
+        result = _validate_address_format(long_addr)
+        assert result is not None
+        assert "Invalid address length" in result
+        assert "100" in result
+
+    def test_bad_prefix_returns_error(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("https://example.com/not-an-address")
+        assert result is not None
+        assert "Unrecognized address format" in result
+
+    def test_valid_legacy_address_passes(self):
+        """Genesis block address."""
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")
+        assert result is None
+
+    def test_valid_p2sh_address_passes(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
+        assert result is None
+
+    def test_valid_bech32_address_passes(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq")
+        assert result is None
+
+    def test_valid_taproot_address_passes(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297")
+        assert result is None
+
+    def test_valid_testnet_bech32_passes(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx")
+        assert result is None
+
+    def test_valid_testnet_p2pkh_passes(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn")
+        assert result is None
+
+    def test_leading_trailing_whitespace_strips_and_validates(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("  1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa  ")
+        assert result is None
+
+    def test_valid_regtest_address_passes(self):
+        from bitcoin_mcp.address_validation import _validate_address_format
+
+        result = _validate_address_format("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+        assert result is None
+


### PR DESCRIPTION
## Summary

Addresses issue #10 — adds fast client-side validation for Bitcoin addresses before sending them to the RPC or external APIs.

## What Changed

**New file:** `src/bitcoin_mcp/address_validation.py`
- `_validate_address_format(address)` returns an error message or ``None``
- Checks: empty/whitespace, length bounds (25-90 chars), valid prefixes (P2PKH/P2SH/Bech32/testnet/regtest)

**Modified:** `src/bitcoin_mcp/server.py`
- Integrated validation into `get_address_utxos`, `validate_address`, `get_address_balance`, `get_address_history`
- Returns clear JSON error before any RPC round-trip for obviously invalid input

**New file:** `tests/test_address_validation.py`
- 14 tests covering all address formats (P2PKH, P2SH, Bech32, P2TR, testnet, regtest)
- Tests for invalid inputs: empty, too short, too long, bad prefix, whitespace handling
- All pass ✅

## Why

Better DX for users and LLM agents — no RPC round-trip needed when the input is clearly not a Bitcoin address.