### PR TITLE
Add Zed editor MCP config example

### DIFF
--- a/examples/zed.json
+++ b/examples/zed.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "Zero config — auto-connects to hosted API if no local node found",
+  "mcpServers": {
+    "bitcoin": {
+      "command": "uvx",
+      "args": ["bitcoin-mcp"]
+    }
+  },
+
+  "_comment_local": "To force a specific local node (uncomment and replace the above)",
+  "_local_example": {
+    "bitcoin": {
+      "command": "uvx",
+      "args": ["bitcoin-mcp"],
+      "env": {
+        "BITCOIN_RPC_HOST": "127.0.0.1",
+        "BITCOIN_RPC_PORT": "8332",
+        "BITCOIN_RPC_USER": "your_rpc_user",
+        "BITCOIN_RPC_PASSWORD": "your_rpc_password"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `examples/zed.json` with Zed editor MCP configuration for bitcoin-mcp.

## Changes

- Added `examples/zed.json` with bitcoin-mcp server configuration
- Supports both zero-config (auto-connect to hosted API) and local Bitcoin Core node modes
- Uses `uvx bitcoin-mcp` command for easy installation

## Motivation

Closes #13. Provides Zed editor users with a ready-to-use MCP configuration, following the pattern established by existing `claude-code.json`, `cursor.json`, and `windsurf.json` examples.

## Testing

- File follows exact schema of existing editor configs
- Valid JSON structure