### PR TITLE
docs: add fee-decision activation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ Pass environment variables to connect to a local Bitcoin Core node or set your A
 docker run -i -e SATOSHI_API_KEY=your-key bitcoin-mcp
 ```
 
+### Ask whether to send Bitcoin now
+
+Use this as the first useful activation path after install:
+
+> "I need to send a Bitcoin transaction today. Use bitcoin-mcp to decide whether to send now or wait, and show the fee rate you used."
+
+Expected path:
+
+1. The agent calls `get_fee_recommendation`.
+2. The answer gives a clear send now or wait recommendation with fee rates in sat/vB.
+3. If you will repeat this check, register a free Satoshi API key and add `SATOSHI_API_KEY` to your MCP config.
+4. If you need a one-off paid API call instead of the MCP tool, use `https://bitcoinsapi.com/x402/start`.
+
+After it works, Star this repo and share a short showcase with the prompt, tool call, and outcome so other Bitcoin agent builders can see the path.
+
 ## Agent Integration
 
 For repos that need Bitcoin tools, add `bitcoin-mcp` to the agent's MCP config and link the Satoshi API integration kit:

--- a/tests/test_readme_activation.py
+++ b/tests/test_readme_activation.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_readme_documents_one_fee_decision_activation_path() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    for phrase in [
+        "Ask whether to send Bitcoin now",
+        "get_fee_recommendation",
+        "send now or wait",
+        "SATOSHI_API_KEY",
+        "Star this repo",
+        "showcase",
+        "https://bitcoinsapi.com/x402/start",
+    ]:
+        assert phrase in readme


### PR DESCRIPTION
## Summary

- add a first-success bitcoin-mcp activation path: ask whether to send Bitcoin now or wait
- point the flow at `get_fee_recommendation`, Satoshi API key setup, and the x402 paid-call fallback
- add README-content coverage so the activation path stays documented

## Validation

- `git diff --check` passed; only the existing Windows LF-to-CRLF warning appeared
- `uv run --extra dev pytest tests/test_readme_activation.py -q` passed: `1 passed in 0.15s`
- `uv run --extra dev pytest tests/ -q` passed earlier in this worktree: `176 passed in 77.76s`

## Boundary

No runtime tool signatures or Bitcoin RPC behavior changed.